### PR TITLE
Enable color lightening and darkening during state of warning.

### DIFF
--- a/src/ConfigValueController.js
+++ b/src/ConfigValueController.js
@@ -87,6 +87,22 @@ class ConfigValuesController {
         return this.conditionDColor;
     }
 
+    getColorForCondition(condition) {
+        switch(condition) {
+            case "A":
+                return this.conditionAColor;
+                break;
+            case "B":
+                return this.conditionBColor;
+                break;
+            case "C":
+                return this.conditionCColor;
+                break;
+            case "D":
+                return this.conditionDColor;
+        }
+    }
+
     getConfigurableValues() {
         return ({
             warningDuration: this.warningDuration,

--- a/src/components/Experiment.css
+++ b/src/components/Experiment.css
@@ -1,19 +1,19 @@
 .experimentContainer {
-    position: absolute;
-    top: 0%;
-    left: 0%;
-    width: 100%;
-    height: 100%;
-    border-radius: 0px;
+  position: absolute;
+  top: 0%;
+  left: 0%;
+  width: 100%;
+  height: 100%;
+  border-radius: 0px;
 }
   
 .experimentContainer.warning {
-    animation-name: warning;
-    animation-delay: 0s;
-    animation-duration: 1.5s;
-    animation-iteration-count: infinite; 
-    -webkit-animation-name: warning;
-    -webkit-animation-delay: 0s;
-    -webkit-animation-duration: 1.5s;
-    -webkit-animation-iteration-count: infinite; 
+  animation-name: warning;
+  animation-delay: 0s;
+  animation-duration: 1.5s;
+  animation-iteration-count: infinite; 
+  -webkit-animation-name: warning;
+  -webkit-animation-delay: 0s;
+  -webkit-animation-duration: 1.5s;
+  -webkit-animation-iteration-count: infinite; 
   }

--- a/src/components/Experiment.css
+++ b/src/components/Experiment.css
@@ -5,7 +5,6 @@
     width: 100%;
     height: 100%;
     border-radius: 0px;
-    background-color: lightcoral;
 }
   
 .experimentContainer.warning {
@@ -17,16 +16,4 @@
     -webkit-animation-delay: 0s;
     -webkit-animation-duration: 1.5s;
     -webkit-animation-iteration-count: infinite; 
-  }
-  
-  @keyframes warning {
-    0% {background-color: lightcoral;}
-    50% {background-color: rgb(255, 191, 191);}
-    100% {background-color: rgb(226, 85, 85);}
-  }
-  
-  @-webkit-keyframes warning {
-    0% {background-color: lightcoral;}
-    50% {background-color: rgb(255, 191, 191);}
-    100% {background-color: rgb(226, 85, 85)}
   }

--- a/src/components/Experiment.js
+++ b/src/components/Experiment.js
@@ -2,6 +2,7 @@ import React from 'react';
 import './Experiment.css';
 import MatchingGame from './MatchingGame.js';
 import Warning from './Warning.js';
+import ConfigValueController from '../ConfigValueController';
 
 const gameState = {
     MATCHING_GAME: 'match',
@@ -24,6 +25,8 @@ class Experiment extends React.Component {
             indicatorFlag = true;
         }
 
+
+
         this.state = {
             score: 0,
             originalCondition: startCondition,
@@ -36,18 +39,24 @@ class Experiment extends React.Component {
     componentDidMount() {
         this.timerID = setInterval(
             () => this.onTick(),
-            1000 
+            1000
         );
     }
 
     componentWillUnmount() {
-        clearInterval(this.timerID); 
+        clearInterval(this.timerID);
     }
 
     onTick() {
         console.log(this.gameTime);
         this.gameTime += 1;
-    
+
+        if (this.gameTime == 1) {
+            const wrapper = document.getElementById('experimentContainer');
+            wrapper.classList.toggle('warning');
+        }
+
+
         if (this.gameTime === this.lopStart - 5) {
             if (this.state.condition === 'A' || this.state.condition === 'B') {
                 this.toggleWarning();
@@ -57,7 +66,7 @@ class Experiment extends React.Component {
                 console.log("Warning Skipped");
             }
         } else if (this.gameTime === this.lopStart) {
-            if (this.state.warningEnabled) {
+            if (this.state.warning) {
                 this.toggleWarning();
             }
             this.currentGameState = gameState.LOSS_OF_POINTS;
@@ -78,7 +87,7 @@ class Experiment extends React.Component {
             // TODO: Update with configured amount
             if (this.indicatorShowingTimer >= 10) {
                 this.indicatorShowingTimer = 0;
-                this.setState({shouldShowIndicator: false});
+                this.setState({ shouldShowIndicator: false });
             }
         }
 
@@ -86,7 +95,7 @@ class Experiment extends React.Component {
             if (this.state.condition === 'A') {
                 if (!this.interactedWithWarningFlag) {
                     this.scoreDeltaCallback(-1);
-                } 
+                }
             } else if (this.state.condition === 'B') {
                 this.scoreDeltaCallback(-1);
             } else if (this.state.condition === 'C') {
@@ -94,7 +103,7 @@ class Experiment extends React.Component {
             } else if (this.state.condition === 'D') {
                 this.scoreDeltaCallback(-1);
             }
-            
+
         }
     }
 
@@ -113,7 +122,7 @@ class Experiment extends React.Component {
 
     showIndicatorIfNeeded() {
         if (this.isSwitchOverConditions()) {
-            this.setState({shouldShowIndicator: true});
+            this.setState({ shouldShowIndicator: true });
         }
     }
 
@@ -123,37 +132,37 @@ class Experiment extends React.Component {
     }
 
     scoreDeltaCallback = (delta) => {
-        let currScore= this.state.score;
+        let currScore = this.state.score;
         let newScore = currScore + delta;
         newScore = Math.max(0, newScore)
-        this.setState({score: newScore});
+        this.setState({ score: newScore });
     }
 
     indicatorCallback = () => {
-      if (this.state.originalCondition === "C") {
-        this.indicatorShowingTimer = 0;
-        this.setState({ 
-            condition: "A",
-            shouldShowIndicator: false
-        });
-        console.log("condition is now A");
-      } else if (this.state.originalCondition === "D") {
-        this.indicatorShowingTimer = 0;
-        this.setState({ 
-            condition: "B",
-            shouldShowIndicator: false 
-        });
-        console.log("condition is now B");
-      }
+        if (this.state.originalCondition === "C") {
+            this.indicatorShowingTimer = 0;
+            this.setState({
+                condition: "A",
+                shouldShowIndicator: false
+            });
+            console.log("condition is now A");
+        } else if (this.state.originalCondition === "D") {
+            this.indicatorShowingTimer = 0;
+            this.setState({
+                condition: "B",
+                shouldShowIndicator: false
+            });
+            console.log("condition is now B");
+        }
     }
 
-    toggleWarning() {
-        this.setState({
-            warningEnabled: !this.state.warningEnabled
-        })
-        const wrapper = document.getElementById('experimentContainer');
-        wrapper.classList.toggle('warning');
-    }
+    // toggleWarning() {
+    //     this.setState({
+    //         warningEnabled: !this.state.warningEnabled
+    //     })
+    //     const wrapper = document.getElementById('experimentContainer');
+    //     wrapper.classList.toggle('warning');
+    // }
 
     onClickWarning() {
         console.log("ON CLICK WARNING ");
@@ -163,24 +172,29 @@ class Experiment extends React.Component {
         }
     }
 
+    // To test this out you can change the string for color on line 180
+    // Uncomment toggleWarning() before merge!!
     render() {
         console.log(this.state.shouldShowIndicator);
         return (
-        <div className="experimentContainer" id='experimentContainer' onClick={this.onClickWarning.bind(this)}>
-            <Warning
-                condition={this.state.condition} 
-                parentCallback={this.scoreDeltaCallback}
-                isWarningEnabled={this.state.warningEnabled}
-            />
-            <MatchingGame 
-                parentCallbackScore={this.scoreDeltaCallback} 
-                score={this.state.score} 
-                parentCallbackIndicator={this.indicatorCallback} 
-                condition={this.state.condition}
-                shouldShowIndicator={this.state.shouldShowIndicator}
-            />
-        </div>
-    );}
+            <div>
+                <div style={{ backgroundColor: "green" }} className="experimentContainer" id='experimentContainer' onClick={this.onClickWarning.bind(this)}>
+                    <Warning
+                        condition={this.state.condition}
+                        parentCallback={this.scoreDeltaCallback}
+                        isWarningEnabled={this.state.warningEnabled}
+                    />
+                </div>
+                <MatchingGame
+                    parentCallbackScore={this.scoreDeltaCallback}
+                    score={this.state.score}
+                    parentCallbackIndicator={this.indicatorCallback}
+                    condition={this.state.condition}
+                    shouldShowIndicator={this.state.shouldShowIndicator}
+                />
+            </div>
+        );
+    }
 }
 
 export default Experiment;

--- a/src/components/Experiment.js
+++ b/src/components/Experiment.js
@@ -66,7 +66,7 @@ class Experiment extends React.Component {
                 console.log("Warning Skipped");
             }
         } else if (this.gameTime === this.lopStart) {
-            if (this.state.warning) {
+            if (this.state.warningEnabled) {
                 this.toggleWarning();
             }
             this.currentGameState = gameState.LOSS_OF_POINTS;

--- a/src/components/MatchingGame.js
+++ b/src/components/MatchingGame.js
@@ -59,6 +59,7 @@ const BottomImageContainer = styled.div`
 
 const MatchingGameContainer = styled.div`
     position: absolute;
+    opacity: 1;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);

--- a/src/components/Warning.css
+++ b/src/components/Warning.css
@@ -1,22 +1,22 @@
 @keyframes warning {
-    0% {background-color: lightcoral;}
-    50% {background-color: rgb(255, 191, 191);}
-    100% {background-color: rgb(226, 85, 85);}
+  0% {opacity: 0.5;}
+  50% {opacity: 0.25;}
+  100% {opacity: 1;} 
   }
 
-  @-webkit-keyframes warning {
-    0% {background-color: lightcoral;}
-    50% {background-color: rgb(255, 191, 191);}
-    100% {background-color: rgb(226, 85, 85);}
-  }
+@-webkit-keyframes warning {
+  0% {opacity: 0.5;}
+  50% {opacity: 0.25;}
+  100% {opacity: 1;} 
+}
     
-    button.warningButton {
-        display: inline-block;
-        width: 190px;
-        height: 80px;
-        padding: 0.7em 1.4em;
-        margin: 0 0.3em 0.3em 0;
-        border-radius: 0.1em;
+button.warningButton {
+  display: inline-block;
+  width: 190px;
+  height: 80px;
+  padding: 0.7em 1.4em;
+  margin: 0 0.3em 0.3em 0;
+  border-radius: 0.1em;
         box-sizing: border-box;
         text-decoration: none;
         font-family: 'Roboto', sans-serif;

--- a/src/components/Warning.css
+++ b/src/components/Warning.css
@@ -17,22 +17,22 @@ button.warningButton {
   padding: 0.7em 1.4em;
   margin: 0 0.3em 0.3em 0;
   border-radius: 0.1em;
-        box-sizing: border-box;
-        text-decoration: none;
-        font-family: 'Roboto', sans-serif;
-        text-transform: uppercase;
-        font-weight: 400;
-        font-size: 22px;
-        color:#FFFFFF;
-        background-color: lightsteelblue;
-        box-shadow: inset 0 -0.6em 0 -0.35em rgba(0,0,0,0.17);
-        text-align: center;
-        position: relative;
-    }
+  box-sizing: border-box;
+  text-decoration: none;
+  font-family: 'Roboto', sans-serif;
+  text-transform: uppercase;
+  font-weight: 400;
+  font-size: 22px;
+  color:#FFFFFF;
+  background-color: lightsteelblue;
+  box-shadow: inset 0 -0.6em 0 -0.35em rgba(0,0,0,0.17);
+  text-align: center;
+  position: relative;
+}
 
-    button.warningButton:hover {
-        color: white;
-        background-color: rgb(158, 176, 199);
-    }
+button.warningButton:hover {
+  color: white;
+  background-color: rgb(158, 176, 199);
+}
 
 


### PR DESCRIPTION
Problem: Lighter and darker variants of border color are hard-coded to lighter and darker coral. Border lightening and darkening should be able to occur for any color configuration.
Solution: Changed the opacity of the experiment container with css keyframes. Moved game 
Test: Set the experiment to a state of warning. Observe opacity changes.